### PR TITLE
enable printing gRPC response

### DIFF
--- a/rundeck-scripts/propose
+++ b/rundeck-scripts/propose
@@ -2,4 +2,5 @@
 set -e
 source "$(dirname $0)/functions"
 
+echo "Proposing..."
 exec python3 $INSTALL_DIR/scripts/propose.py

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -5,7 +5,7 @@ from rchain.crypto import PrivateKey
 from rchain.client import RClient
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
+root.setLevel(logging.DEBUG)
 
 with grpc.insecure_channel('localhost:40401') as channel:
     client = RClient(channel)

--- a/scripts/propose.py
+++ b/scripts/propose.py
@@ -1,16 +1,20 @@
 import grpc
 import logging
+import sys
 from rchain.client import RClient
 from rchain.client import RClientException
 
 root = logging.getLogger()
-root.setLevel(logging.INFO)
+root.setLevel(logging.DEBUG)
 
+ret=0
 with grpc.insecure_channel('localhost:40401') as channel:
     client = RClient(channel)
     try:
         client.propose()
     except RClientException as e:
-        # NoNewDeploys is a valid scenario
+        # NoNewDeploys case should not exit with an error \
+        # so autopropose script can deploy again before next propose
         if "NoNewDeploys" not in str(e):
-            raise
+            ret=1
+sys.exit(ret)


### PR DESCRIPTION
I believe we should mute RClientException, as it prints stack trace and its not useful at all. And enable debug messages so we can see gRPC response strings.