### PR TITLE
GCSfuse stores uploaded file in /tmp which is too small for 100G+ fil…

### DIFF
--- a/mnt-heapdumps.mount
+++ b/mnt-heapdumps.mount
@@ -5,7 +5,7 @@ After=network.target
 What=heapdumps.bucket.rchain-dev.tk
 Where=/mnt/heapdumps
 Type=gcsfuse
-Options=_netdev,limit_ops_per_sec=-1,key_file=/root/heapdumps-access-developer-222401-dd77d48e137e.json
+Options=_netdev,limit_ops_per_sec=-1,key_file=/root/heapdumps-access-developer-222401-dd77d48e137e.json,--temp-dir=/rchain/tmp
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
…es on IBM Cloud