### PR TITLE
add protobuf old version

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -13,3 +13,4 @@ grpcio>=1.18.0
 grpcio-status>=1.18.0
 googleapis-common-protos>=1.5.5
 pyjq
+protobuf==3.20.1


### PR DESCRIPTION
Error with latest install 

```
Jun 22 17:55:15 ip-10-0-1-5 propose.sh[9510]: If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
Jun 22 17:55:15 ip-10-0-1-5 propose.sh[9510]: If you cannot immediately regenerate your protos, some other possible workarounds are:
Jun 22 17:55:15 ip-10-0-1-5 propose.sh[9510]:  1. Downgrade the protobuf package to 3.20.x or lower.
Jun 22 17:55:15 ip-10-0-1-5 propose.sh[9510]:  2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
Jun 22 17:55:15 ip-10-0-1-5 propose.sh[9510]: More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
Jun 22 17:55:15 ip-10-0-1-5 systemd[1]: mainnet-propose-orchestrator.service: Main process exited, code=exited, status=1/FAILURE
Jun 22 17:55:15 ip-10-0-1-5 systemd[1]: mainnet-propose-orchestrator.service: Failed with result 'exit-code'.
```